### PR TITLE
Support JAX JIT

### DIFF
--- a/examples/single_image.py
+++ b/examples/single_image.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 import imageio.v3 as iio
 import optax
 import argparse
+import time
 
 
 def main(
@@ -14,45 +15,55 @@ def main(
     out_img_path: str,
     out_vid_path: str,
 ):
-    key = jax.random.key(0)
-
     gt = jnp.array(iio.imread(gt_path)).astype(jnp.float32)[..., :3] / 255
 
-    key, subkey = jax.random.split(key)
-    params, coeffs = init(subkey, num_points, gt.shape[:2])
+    key = jax.random.key(0)
+    params, coeffs = init(key, num_points, gt.shape[:2])
 
-    optim = optax.adam(lr)
-    optim_state = optim.init(params)
+    optimizer = optax.adam(lr)
+    optimizer_state = optimizer.init(params)
 
-    def loss_fn(params, coeffs, gt):
+    def loss_fn(params):
         output = render_fn(params, coeffs)
         loss = jnp.mean(jnp.square(output - gt))
         return loss
 
-    def train(params, optim_state, video):
+    # @jax.jit
+    def train_step(
+        params,
+        optimizer_state: optax.OptState,
+    ):
+        loss, grads = jax.value_and_grad(loss_fn)(params)
+        updates, optimizer_state = optimizer.update(grads, optimizer_state)
+        params = optax.apply_updates(params, updates)
+
+        return params, optimizer_state, loss
+
+    log_every = 50
+    with iio.imopen(out_vid_path, "w", plugin="pyav") as video:
+        video.init_video_stream("h264")
+
+        cum_time = 0
+        cum_time_split = 0
         for i in range(iterations):
-            if video is not None:
-                img = (render_fn(params, coeffs) * 255).astype(jnp.uint8)
-                video.write_frame(img)
+            img = (render_fn(params, coeffs) * 255).astype(jnp.uint8)
+            video.write_frame(img)
 
-            loss, grads = jax.value_and_grad(loss_fn, argnums=0)(params, coeffs, gt)
-            updates, optim_state = optim.update(grads, optim_state)
-            params = optax.apply_updates(params, updates)
+            start = time.perf_counter()
+            params, optimizer_state, loss = train_step(params, optimizer_state)
+            end = time.perf_counter()
 
-            if i % 50 == 0:
-                print(f"iter {i} loss {loss.item():.5f}")
+            cum_time += end - start
+            cum_time_split += end - start
 
-            if loss < 1e-3:
-                break
-
-    train_jit = train
-
-    if out_vid_path != "":
-        with iio.imopen(out_vid_path, "w", plugin="pyav") as video:
-            video.init_video_stream("h264")
-            train_jit(params, optim_state, video)
-    else:
-        train_jit(params, optim_state, None)
+            if i % log_every == 0:
+                print(
+                    f"iter {i} loss {loss:.4f}, {cum_time_split/log_every*1000:.3f}ms avg per step"
+                )
+                cum_time_split = 0
+        print(
+            f"done training in {cum_time:.3f}s ({cum_time/iterations*1000:.3f}ms avg per step)"
+        )
 
     out = render_fn(params, coeffs)
     iio.imwrite(out_img_path, (out * 255).astype(jnp.uint8))
@@ -136,19 +147,7 @@ def render_fn(params, coeffs):
     colors = jax.nn.sigmoid(params["colors"])
     opacities = jax.nn.sigmoid(params["opacities"])
 
-    render_jit = jax.jit(
-        jaxsplat.render,
-        static_argnames=(
-            "img_shape",
-            "f",
-            "c",
-            "glob_scale",
-            "clip_thresh",
-            "block_size",
-        ),
-    )
-    # render_jit = jaxsplat.render
-    img = render_jit(
+    img = jaxsplat.render(
         means3d=means3d,
         scales=scales,
         quats=quats,
@@ -156,7 +155,7 @@ def render_fn(params, coeffs):
         opacities=opacities,
         viewmat=coeffs["viewmat"],
         background=coeffs["background"],
-        img_shape=(1156, 1528),
+        img_shape=coeffs["img_shape"],
         f=coeffs["f"],
         c=coeffs["c"],
         glob_scale=coeffs["glob_scale"],

--- a/jaxsplat/_project/__init__.py
+++ b/jaxsplat/_project/__init__.py
@@ -1,8 +1,56 @@
 import jax
 
 from typing import TypedDict
+from dataclasses import dataclass
+from functools import partial
 
 from jaxsplat._project import impl
+
+
+@jax.tree_util.register_pytree_node_class
+@dataclass(frozen=True, kw_only=True)
+class ProjectDescriptor:
+    num_points: int
+    img_shape: tuple[int, int]
+    f: tuple[float, float]
+    c: tuple[float, float]
+    glob_scale: float
+    clip_thresh: float
+    block_width: int
+
+    def tree_flatten(self):
+        children = ()
+        aux = (
+            self.num_points,
+            self.img_shape,
+            self.f,
+            self.c,
+            self.glob_scale,
+            self.clip_thresh,
+            self.block_width,
+        )
+        return children, aux
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        (
+            num_points,
+            img_shape,
+            f,
+            c,
+            glob_scale,
+            clip_thresh,
+            block_width,
+        ) = aux
+        return cls(
+            num_points=num_points,
+            img_shape=img_shape,
+            f=f,
+            c=c,
+            glob_scale=glob_scale,
+            clip_thresh=clip_thresh,
+            block_width=block_width,
+        )
 
 
 def project(
@@ -18,42 +66,8 @@ def project(
     clip_thresh: float,
     block_width: int,
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
-    (xys, depths, radii, conics, num_tiles_hit, cum_tiles_hit, _compensation) = (
-        _project(
-            mean3ds,
-            scales,
-            quats,
-            viewmat,
-            glob_scale=glob_scale,
-            f=f,
-            c=c,
-            img_shape=img_shape,
-            block_width=block_width,
-            clip_thresh=clip_thresh,
-        )
-    )
-    return (xys, depths, radii, conics, num_tiles_hit, cum_tiles_hit)
-
-
-@jax.custom_vjp
-def _project(
-    mean3ds: jax.Array,
-    scales: jax.Array,
-    quats: jax.Array,
-    viewmat: jax.Array,
-    #
-    img_shape: tuple[int, int],
-    f: tuple[float, float],
-    c: tuple[float, float],
-    glob_scale: float,
-    clip_thresh: float,
-    block_width: int,
-):
-    primals, _ = _project_fwd(
-        mean3ds,
-        scales,
-        quats,
-        viewmat,
+    desc = ProjectDescriptor(
+        num_points=mean3ds.shape[0],
         glob_scale=glob_scale,
         f=f,
         c=c,
@@ -61,6 +75,27 @@ def _project(
         block_width=block_width,
         clip_thresh=clip_thresh,
     )
+    (xys, depths, radii, conics, num_tiles_hit, cum_tiles_hit, _compensation) = (
+        _project(
+            desc,
+            mean3ds,
+            scales,
+            quats,
+            viewmat,
+        )
+    )
+    return (xys, depths, radii, conics, num_tiles_hit, cum_tiles_hit)
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(0,))
+def _project(
+    desc: ProjectDescriptor,
+    mean3ds: jax.Array,
+    scales: jax.Array,
+    quats: jax.Array,
+    viewmat: jax.Array,
+):
+    primals, _ = _project_fwd(desc, mean3ds, scales, quats, viewmat)
 
     return primals
 
@@ -76,63 +111,29 @@ class ProjectResiduals(TypedDict):
     conics: jax.Array
     compensation: jax.Array
 
-    num_points: int
-    img_shape: tuple[int, int]
-    f: tuple[float, float]
-    c: tuple[float, float]
-    glob_scale: float
-    clip_thresh: float
-    block_width: int
-
 
 def _project_fwd(
+    desc: ProjectDescriptor,
     mean3ds: jax.Array,
     scales: jax.Array,
     quats: jax.Array,
     viewmat: jax.Array,
-    #
-    img_shape: tuple[int, int],
-    f: tuple[float, float],
-    c: tuple[float, float],
-    glob_scale: float,
-    clip_thresh: float,
-    block_width: int,
 ):
-    num_points = mean3ds.shape[0]
-
     (cov3ds, xys, depths, radii, conics, compensation, num_tiles_hit, cum_tiles_hit) = (
         impl._project_fwd_p.bind(
             mean3ds,
             scales,
             quats,
             viewmat,
-            num_points=num_points,
-            img_shape=img_shape,
-            f=f,
-            c=c,
-            glob_scale=glob_scale,
-            clip_thresh=clip_thresh,
-            block_width=block_width,
+            num_points=desc.num_points,
+            img_shape=desc.img_shape,
+            f=desc.f,
+            c=desc.c,
+            glob_scale=desc.glob_scale,
+            clip_thresh=desc.clip_thresh,
+            block_width=desc.block_width,
         )
     )
-
-    # print("project_fwd")
-
-    # print("in")
-    # print(f"  mean3ds {mean3ds.min():.03f} {mean3ds.max():.03f}")
-    # print(f"  scales {scales.min():.03f} {scales.max():.03f}")
-    # print(f"  quats {quats.min():.03f} {quats.max():.03f}")
-    # print(f"  viewmat {viewmat.min():.03f} {viewmat.max():.03f}")
-
-    # print("out")
-    # print(f"  cov3ds {cov3ds.min():.03f} {cov3ds.max():.03f}")
-    # print(f"  xys {xys.min():.03f} {xys.max():.03f}")
-    # print(f"  depths {depths.min():.03f} {depths.max():.03f}")
-    # print(f"  radii {radii.min():.03f} {radii.max():.03f}")
-    # print(f"  conics {conics.min():.03f} {conics.max():.03f}")
-    # print(f"  compensation {compensation.min():.03f} {compensation.max():.03f}")
-    # print(f"  num_tiles_hit {num_tiles_hit.min():.03f} {num_tiles_hit.max():.03f}")
-    # print(f"  cum_tiles_hit {cum_tiles_hit.min():.03f} {cum_tiles_hit.max():.03f}")
 
     primals = (xys, depths, radii, conics, num_tiles_hit, cum_tiles_hit, compensation)
 
@@ -146,20 +147,13 @@ def _project_fwd(
         "radii": radii,
         "conics": conics,
         "compensation": compensation,
-        #
-        "num_points": num_points,
-        "img_shape": img_shape,
-        "f": f,
-        "c": c,
-        "glob_scale": glob_scale,
-        "clip_thresh": clip_thresh,
-        "block_width": block_width,
     }
 
     return primals, residuals
 
 
 def _project_bwd(
+    desc: ProjectDescriptor,
     residuals: ProjectResiduals,
     cotangents,
 ):
@@ -172,8 +166,6 @@ def _project_bwd(
         _v_cum_tiles_hit,
         v_compensation,
     ) = cotangents
-
-    num_points = residuals["mean3ds"].shape[0]
 
     (
         v_mean3d,
@@ -196,40 +188,19 @@ def _project_bwd(
         v_depth,
         v_conic,
         #
-        num_points=num_points,
-        img_shape=residuals["img_shape"],
-        f=residuals["f"],
-        c=residuals["c"],
-        glob_scale=residuals["glob_scale"],
-        clip_thresh=residuals["clip_thresh"],
-        block_width=residuals["block_width"],
+        num_points=desc.num_points,
+        img_shape=desc.img_shape,
+        f=desc.f,
+        c=desc.c,
+        glob_scale=desc.glob_scale,
+        clip_thresh=desc.clip_thresh,
+        block_width=desc.block_width,
     )
-
-    # print("project_bwd")
-
-    # print("in")
-    # print(f"  v_xy {v_xy.min():.03f} {v_xy.max():.03f}")
-    # print(f"  v_depth {v_depth.min():.03f} {v_depth.max():.03f}")
-    # print(f"  v_conic {v_conic.min():.03f} {v_conic.max():.03f}")
-    # print(f"  v_compensation {v_compensation.min():.03f} {v_compensation.max():.03f}")
-
-    # print("out")
-    # print(f"  v_mean3d {v_mean3d.min():.03f} {v_mean3d.max():.03f}")
-    # print(f"  v_scale {v_scale.min():.03f} {v_scale.max():.03f}")
-    # print(f"  v_quat {v_quat.min():.03f} {v_quat.max():.03f}")
-    # print(f"  v_cov2d {v_cov2d.min():.03f} {v_cov2d.max():.03f}")
-    # print(f"  v_cov3d {v_cov3d.min():.03f} {v_cov3d.max():.03f}")
 
     return (
         v_mean3d,
         v_scale,
         v_quat,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
         None,
     )
 

--- a/jaxsplat/_project/lowering.py
+++ b/jaxsplat/_project/lowering.py
@@ -27,7 +27,6 @@ def _project_fwd_rule(
 ):
     opaque = _jaxsplat.make_descriptor(
         num_points=num_points,
-        num_intersects=0,
         img_shape=img_shape,
         f=f,
         c=c,
@@ -103,7 +102,6 @@ def _project_bwd_rule(
 ):
     opaque = _jaxsplat.make_descriptor(
         num_points=num_points,
-        num_intersects=0,
         img_shape=img_shape,
         f=f,
         c=c,

--- a/jaxsplat/_rasterize/abstract.py
+++ b/jaxsplat/_rasterize/abstract.py
@@ -8,14 +8,8 @@ class RasterizeFwdTypes:
     def __init__(
         self,
         num_points: int,
-        num_intersects: int,
         img_shape: tuple[int, int],
-        block_width: int,
     ):
-        num_tiles = ((img_shape[0] + block_width - 1) // block_width) * (
-            (img_shape[1] + block_width - 1) // block_width
-        )
-
         self.in_colors = Type((num_points, 3), jnp.float32)
         self.in_opacities = Type((num_points, 1), jnp.float32)
         self.in_background = Type((3,), jnp.float32)
@@ -25,8 +19,6 @@ class RasterizeFwdTypes:
         self.in_conics = Type((num_points, 3), jnp.float32)
         self.in_cum_tiles_hit = Type((num_points, 1), jnp.uint32)
 
-        self.out_gaussian_ids_sorted = Type((num_intersects, 1), jnp.int32)
-        self.out_tile_bins = Type((num_tiles, 2), jnp.int32)
         self.out_final_Ts = Type((*img_shape, 1), jnp.float32)
         self.out_final_idx = Type((*img_shape, 1), jnp.int32)
         self.out_img = Type((*img_shape, 3), jnp.float32)
@@ -43,15 +35,12 @@ def _rasterize_fwd_abs(
     cum_tiles_hit: jax.Array,
     #
     num_points: int,
-    num_intersects: int,
     img_shape: tuple[int, int],
     block_width: int,
 ):
     t = RasterizeFwdTypes(
         num_points,
-        num_intersects,
         img_shape,
-        block_width,
     )
 
     t.in_colors.assert_(colors)
@@ -64,8 +53,6 @@ def _rasterize_fwd_abs(
     t.in_cum_tiles_hit.assert_(cum_tiles_hit)
 
     return (
-        t.out_gaussian_ids_sorted.shaped_array(),
-        t.out_tile_bins.shaped_array(),
         t.out_final_Ts.shaped_array(),
         t.out_final_idx.shaped_array(),
         t.out_img.shaped_array(),
@@ -76,20 +63,16 @@ class RasterizeBwdTypes:
     def __init__(
         self,
         num_points: int,
-        num_intersects: int,
         img_shape: tuple[int, int],
-        block_width: int,
     ):
-        num_tiles = ((img_shape[0] + block_width - 1) // block_width) * (
-            (img_shape[1] + block_width - 1) // block_width
-        )
         self.in_colors = Type((num_points, 3), jnp.float32)
         self.in_opacities = Type((num_points, 1), jnp.float32)
         self.in_background = Type((3,), jnp.float32)
         self.in_xys = Type((num_points, 2), jnp.float32)
+        self.in_depths = Type((num_points, 1), jnp.float32)
+        self.in_radii = Type((num_points, 1), jnp.int32)
         self.in_conics = Type((num_points, 3), jnp.float32)
-        self.in_gaussian_ids_sorted = Type((num_intersects, 1), jnp.int32)
-        self.in_tile_bins = Type((num_tiles, 2), jnp.int32)
+        self.in_cum_tiles_hit = Type((num_points, 1), jnp.uint32)
         self.in_final_Ts = Type((*img_shape, 1), jnp.float32)
         self.in_final_idx = Type((*img_shape, 1), jnp.int32)
         self.in_v_img = Type((*img_shape, 3), jnp.float32)
@@ -107,28 +90,29 @@ def _rasterize_bwd_abs(
     opacities: jax.Array,
     background: jax.Array,
     xys: jax.Array,
+    depths: jax.Array,
+    radii: jax.Array,
     conics: jax.Array,
-    gaussian_ids_sorted: jax.Array,
-    tile_bins: jax.Array,
+    cum_tiles_hit: jax.Array,
     final_Ts: jax.Array,
     final_idx: jax.Array,
     v_img: jax.Array,
     v_img_alpha: jax.Array,
     #
     num_points: int,
-    num_intersects: int,
     img_shape: tuple[int, int],
     block_width: int,
 ):
-    t = RasterizeBwdTypes(num_points, num_intersects, img_shape, block_width)
+    t = RasterizeBwdTypes(num_points, img_shape)
 
     t.in_colors.assert_(colors)
     t.in_opacities.assert_(opacities)
     t.in_background.assert_(background)
     t.in_xys.assert_(xys)
+    t.in_depths.assert_(depths)
+    t.in_radii.assert_(radii)
     t.in_conics.assert_(conics)
-    t.in_gaussian_ids_sorted.assert_(gaussian_ids_sorted)
-    t.in_tile_bins.assert_(tile_bins)
+    t.in_cum_tiles_hit.assert_(cum_tiles_hit)
     t.in_final_Ts.assert_(final_Ts)
     t.in_final_idx.assert_(final_idx)
     t.in_v_img.assert_(v_img)

--- a/jaxsplat/_rasterize/lowering.py
+++ b/jaxsplat/_rasterize/lowering.py
@@ -22,13 +22,11 @@ def _rasterize_fwd_rule(
     cum_tiles_hit: ir.Value,
     #
     num_points: int,
-    num_intersects: int,
     img_shape: tuple[int, int],
     block_width: int,
 ):
     opaque = _jaxsplat.make_descriptor(
         num_points=num_points,
-        num_intersects=num_intersects,
         img_shape=img_shape,
         f=(0.0, 0.0),
         c=(0.0, 0.0),
@@ -37,7 +35,7 @@ def _rasterize_fwd_rule(
         block_width=block_width,
     )
 
-    t = RasterizeFwdTypes(num_points, num_intersects, img_shape, block_width)
+    t = RasterizeFwdTypes(num_points, img_shape)
 
     return custom_call(
         "rasterize_fwd",
@@ -62,15 +60,11 @@ def _rasterize_fwd_rule(
             t.in_cum_tiles_hit.layout(),
         ],
         result_types=[
-            t.out_gaussian_ids_sorted.ir_tensor_type(),
-            t.out_tile_bins.ir_tensor_type(),
             t.out_final_Ts.ir_tensor_type(),
             t.out_final_idx.ir_tensor_type(),
             t.out_img.ir_tensor_type(),
         ],
         result_layouts=[
-            t.out_gaussian_ids_sorted.layout(),
-            t.out_tile_bins.layout(),
             t.out_final_Ts.layout(),
             t.out_final_idx.layout(),
             t.out_img.layout(),
@@ -86,22 +80,21 @@ def _rasterize_bwd_rule(
     opacities: ir.Value,
     background: ir.Value,
     xys: ir.Value,
+    depths: ir.Value,
+    radii: ir.Value,
     conics: ir.Value,
-    gaussian_ids_sorted: ir.Value,
-    tile_bins: ir.Value,
+    cum_tiles_hit: ir.Value,
     final_Ts: ir.Value,
     final_idx: ir.Value,
     v_img: ir.Value,
     v_img_alpha: ir.Value,
     #
     num_points: int,
-    num_intersects: int,
     img_shape: tuple[int, int],
     block_width: int,
 ):
     opaque = _jaxsplat.make_descriptor(
         num_points=num_points,
-        num_intersects=num_intersects,
         img_shape=img_shape,
         f=(0.0, 0.0),
         c=(0.0, 0.0),
@@ -110,7 +103,7 @@ def _rasterize_bwd_rule(
         block_width=block_width,
     )
 
-    t = RasterizeBwdTypes(num_points, num_intersects, img_shape, block_width)
+    t = RasterizeBwdTypes(num_points, img_shape)
 
     return custom_call(
         "rasterize_bwd",
@@ -119,9 +112,10 @@ def _rasterize_bwd_rule(
             opacities,
             background,
             xys,
+            depths,
+            radii,
             conics,
-            gaussian_ids_sorted,
-            tile_bins,
+            cum_tiles_hit,
             final_Ts,
             final_idx,
             v_img,
@@ -132,9 +126,10 @@ def _rasterize_bwd_rule(
             t.in_opacities.layout(),
             t.in_background.layout(),
             t.in_xys.layout(),
+            t.in_depths.layout(),
+            t.in_radii.layout(),
             t.in_conics.layout(),
-            t.in_gaussian_ids_sorted.layout(),
-            t.in_tile_bins.layout(),
+            t.in_cum_tiles_hit.layout(),
             t.in_final_Ts.layout(),
             t.in_final_idx.layout(),
             t.in_v_img.layout(),

--- a/lib/ffi.cu
+++ b/lib/ffi.cu
@@ -14,7 +14,6 @@ py::dict registrations() {
 
 py::bytes make_descriptor(
     unsigned num_points,
-    unsigned num_intersects,
     std::pair<unsigned, unsigned> img_shape,
     std::pair<float, float> f,
     std::pair<float, float> c,
@@ -38,7 +37,6 @@ py::bytes make_descriptor(
 
     ops::Descriptor desc = {
         num_points,
-        num_intersects,
         img_shape_dim3,
         intrins,
         glob_scale,
@@ -60,7 +58,6 @@ PYBIND11_MODULE(_jaxsplat, m) {
         "make_descriptor",
         make_descriptor,
         py::arg("num_points"),
-        py::arg("num_intersects"),
         py::arg("img_shape"),
         py::arg("f"),
         py::arg("c"),

--- a/lib/ops.h
+++ b/lib/ops.h
@@ -8,7 +8,6 @@ namespace ops {
 
 struct Descriptor {
     unsigned num_points;
-    unsigned num_intersects;
     dim3 img_shape;
 
     float4 intrins;
@@ -164,15 +163,14 @@ struct rasterize::fwd::Tensors {
         const int *cum_tiles_hit;
     } in;
     struct Out {
-        // sort and bin
-        int *gaussian_ids_sorted;
-        int2 *tile_bins;
-
         // rasterization output
         float *final_Ts;
         int *final_idx;
         float3 *out_img;
     } out;
+
+    int *gaussian_ids_sorted;
+    int2 *tile_bins;
 };
 
 struct rasterize::bwd::Tensors {
@@ -184,11 +182,10 @@ struct rasterize::bwd::Tensors {
 
         // projection output
         const float2 *xys;
+        const float *depths;
+        const int *radii;
         const float3 *conics;
-
-        // sorting and binning
-        const int *gaussian_ids_sorted;
-        const int2 *tile_bins;
+        const int *cum_tiles_hit;
 
         // rasterization output
         const float *final_Ts;
@@ -208,6 +205,9 @@ struct rasterize::bwd::Tensors {
         float2 *v_xy_abs;
         float3 *v_conic;
     } out;
+
+    int *gaussian_ids_sorted;
+    int2 *tile_bins;
 };
 
 } // namespace ops


### PR DESCRIPTION
This PR enables JAX JIT support (#1).

`gaussian_ids` is recalculated in `ops:rasterize::bwd::xla` so that `ops::rasterize::fwd::xla` does not have to leak dynamically shaped arrays into JAX-side code.

This does mean duplicate computations will happen on the forward and backward pass, looking for a more efficient approach in the future may be worth it.

Achieves a ~16% speed improvement on the single image example, improvements will be bigger for more code involving more JAX operations.