### PR TITLE
Make jaxsplat work on modern jax.

### DIFF
--- a/jaxsplat/_types.py
+++ b/jaxsplat/_types.py
@@ -1,7 +1,7 @@
 import jax
 from jax.interpreters import mlir
 from jax.interpreters.mlir import ir
-from jax.core import ShapedArray, canonicalize_shape
+from jax.core import ShapedArray
 import jax.numpy as jnp
 from jax.typing import DTypeLike
 from jax.dtypes import canonicalize_dtype
@@ -12,7 +12,7 @@ class Type:
     dtype: jnp.dtype
 
     def __init__(self, shape: tuple[int, ...], dtype: DTypeLike):
-        self.shape = canonicalize_shape(shape)
+        self.shape = shape
         self.dtype = jnp.dtype(dtype)
 
     def ir_type(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["scikit-build-core"]
+requires = ["scikit-build-core", "pybind11"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "jaxsplat"
 version = "0.1.0"
 readme = "README.md"
-license = {file = "LICENSE.txt"}
+license = { file = "LICENSE.txt" }
 
 [tool.setuptools]
 cmake.version = ">=3.24"


### PR DESCRIPTION
This PR removes the deprecated canonicalize_shape from `_types.py`.  Also add a  dependency on pybind11 explicitly in the  pyproject toml to make sure that the package can be easily integrated in other python projects.